### PR TITLE
Make it easier to contribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea/
+npm-debug.log*
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Development
+
+## Dependencies
+
+Run the following to install all dependencies:
+
+```bash
+$ npm install
+```
+
+## Build
+
+Two steps are necessary to build the project entirely:
+
+```bash
+$ npm run build
+```

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "less-plugin-autoprefix": "^1.5.1",
     "requirejs": "^2.1.22",
     "run-sequence": "^1.1.2"
+  },
+  "scripts": {
+    "build": "gulp less && gulp build"
   }
 }


### PR DESCRIPTION
- Created build script in package.json. Why?
  - To only need to run one command to build the project
  - With that, `gulp` dependency can be used directly from `node_modules` folder and doesn't require a global installation
- Created a `CONTRIBUTING.md` for other to know what they need to do when they want to develop in the project
- Ignored default npm-debug.log files and PHPStorm/Webstorm config files